### PR TITLE
Makefile now works for me too

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,80 @@
+name: build
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup RiscV toolchain
+        # Locked the commit-id of the version as this is a 3rd party action
+        # tag gregdavill/setup-riscv-gnu-toolchain#v2 is a707fbefff8a80dc19007cd4bd3eb74ccbf76542 on 11-Nov-2023
+        uses: gregdavill/setup-riscv-gnu-toolchain@a707fbefff8a80dc19007cd4bd3eb74ccbf76542
+        #with:
+        #  version: 11.3.0-1
+
+      - name: Setup PATH
+        shell: bash
+        run: |
+          echo "=== $RUNNER_TEMP/.setup-riscv-gnu-toolchain/bin:"
+          ls -la $RUNNER_TEMP/.setup-riscv-gnu-toolchain/bin
+
+          echo "=== $RUNNER_TEMP/.setup-riscv-gnu-toolchain/riscv-none-elf/bin:"
+          ls -la $RUNNER_TEMP/.setup-riscv-gnu-toolchain/riscv-none-elf/bin
+
+          echo "${RUNNER_TEMP}/.setup-riscv-gnu-toolchain/bin" >> $GITHUB_PATH
+
+      - name: Summary
+        shell: bash
+        run: |
+          TOOLCHAIN_PREFIX="riscv-none-elf-"
+
+          ${TOOLCHAIN_PREFIX}ld -v
+          ${TOOLCHAIN_PREFIX}gcc -v
+          ${TOOLCHAIN_PREFIX}as -v </dev/null
+
+          ${TOOLCHAIN_PREFIX}gcc -dumpspecs
+
+          ${TOOLCHAIN_PREFIX}gcc -dumpspecs 2>/dev/null | grep -i -E "^march" | grep -i    -E "_zicsr"
+          ${TOOLCHAIN_PREFIX}gcc -dumpspecs 2>/dev/null | grep -i -E "^march" | grep -i -c -E "_zicsr"
+
+          version_gcc=$(${TOOLCHAIN_PREFIX}gcc --version | head -n1)
+          version_as=$( ${TOOLCHAIN_PREFIX}as  -v </dev/null 2>&1 >/dev/null | head -n1)
+          version_ld=$( ${TOOLCHAIN_PREFIX}ld  --version | head -n1)
+        
+          cat <<EOF >/tmp/GITHUB_STEP_SUMMARY$$.txt
+          | Package  | Version        |
+          | -------- | -------------- |
+          | binutils | ${version_ld}  |
+          | gcc      | ${version_gcc} |
+          | as       | ${version_as}  |
+          EOF
+
+          cat /tmp/GITHUB_STEP_SUMMARY$$.txt
+          cat /tmp/GITHUB_STEP_SUMMARY$$.txt >> $GITHUB_STEP_SUMMARY
+
+      - name: Build
+        shell: bash
+        run: |
+          export TOOLCHAIN_PATH=""
+          export TOOLCHAIN_PREFIX="riscv-none-elf-"
+        
+          make
+
+      - name: Upload firmware
+        uses: actions/upload-artifact@v3
+        with:
+          name: firmware
+          path: |
+            **/*.bin
+            **/*.elf
+            **/*.hex
+            **/*.lst
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *hex
 *lst
 *bin
+*.elf

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,92 @@
-TOOLCHAIN_PATH=/opt/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin/
-FLASH_PATH=../flasher/ft2232h
-TOOLCHAIN_PREFIX=riscv64-unknown-elf
+#
+# Configure your RiscV toolchain path and prefix
+#
+TOOLCHAIN_PATH		?= /opt/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin/
+TOOLCHAIN_PREFIX	?= riscv64-unknown-elf-
 
-flash_tigard: ${PATTERN}.bin
-	PYTHONPATH=$(FLASH_PATH) python3 $(FLASH_PATH)/caravelflash/flash_util.py  --write $<
+# This path appears to be outside this project tree, so maybe instructions here to download this tool ?
+FLASH_PATH		?= ../flasher/ft2232h
 
-%.elf: %.c ../deps/sections.lds ../deps/crt0_vex.S
-	$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)-gcc -I../deps -I../deps/generated/ -O0 -mabi=ilp32 -march=rv32i -D__vexriscv__ -Wl,-Bstatic,-T,../deps/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ ../deps/crt0_vex.S ../deps/isr.c ../deps/stub.c $<
-	${TOOLCHAIN_PATH}$(TOOLCHAIN_PREFIX)-objdump -D $@ > ${PATTERN}.lst
+
+ifeq ($(MAKELEVEL),0)
+ ifeq (deps,$(wildcard deps))
+# Top level only
+ROOTDIR			= $(CURDIR)
+SUBMODULES		= tt02-test
+ else
+# Subdir module is toplevel
+ROOTDIR			= $(PWD)/..
+ endif
+export ROOTDIR
+unexport SUBMODULES
+endif
+
+
+GENDIR  = -I$(ROOTDIR)/deps/generated
+INCDIRS = -I$(ROOTDIR)/deps $(GENDIR)
+
+GCC	= $(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)gcc
+OBJDUMP	= $(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)objdump
+OBJCOPY = $(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)objcopy
+
+# VexRiscV on Caravel
+CFLAGS_ARCH	=	-mabi=ilp32 -march=rv32i -D__vexriscv__ -mstrict-align
+
+#
+CFLAGS_CODEGEN	= -O0
+# For caravel production reduce code size and amount of stack usage around function calls and
+#   set RiscV ABI minimum frame size (16 bytes) due to the limited RAM caravel has 1.5KiB.
+#CFLAGS_CODEGEN	=	-Os -fomit-frame-pointer -mpreferred-stack-boundary=4
+
+CFLAGS		=	-Wall
+
+SRC_FILES	=	crt0_vex.S \
+			isr.c \
+			stub.c
+
+SRCS		=	$(addprefix $(ROOTDIR)/deps/,$(SRC_FILES))
+
+all: submodule-all
+
+
+submodule-all:
+	@for submodule in $(SUBMODULES); do \
+		$(MAKE) -C $${submodule} submodule-all; \
+	done
+
+
+flash_tigard: $(PATTERN).bin
+	@if [ ! -e "$(FLASH_PATH)" ]; then \
+		echo "###" 1>&2; \
+		echo "### WARNING: FLASH OPERATION SKIPPED"; 1>&2 \
+		echo "###" 1>&2; \
+		echo "###          FLASH_PATH=${FLASH_PATH} does not exist (please install flasher)" 1>&2; \
+		echo "###" 1>&2; \
+		exit 0; \
+	else \
+		PYTHONPATH=$(FLASH_PATH) python3 $(FLASH_PATH)/caravelflash/flash_util.py  --write $<; \
+	fi
+
+%.elf: %.c $(ROOTDIR)/deps/sections.lds $(SRCS)
+	$(GCC) $(INCDIRS) $(CFLAGS_CODEGEN) $(CFLAGS_ARCH) $(CFLAGS) -Wl,-Bstatic,-T,$(ROOTDIR)/deps/sections.lds,--strip-debug -ffreestanding -nostdlib -o $@ $(SRCS) $<
+	$(OBJDUMP) -D $@ > $(PATTERN).lst
 
 %.hex: %.elf
-	$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)-objcopy -O verilog $< $@
+	$(OBJCOPY) -O verilog $< $@
 	sed -i 's/@1000/@0000/g' $@
 
 %.bin: %.elf
-	$(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)-objcopy -O binary $< $@
+	$(OBJCOPY) -O binary $< $@
 
 # ---- Clean ----
 
 clean:
+	@for submodule in $(SUBMODULES); do \
+		$(MAKE) -C $${submodule} clean; \
+	done
 	rm -f *.elf *.hex *.bin *.lst
 
 monitor:
 	pio device monitor -p /dev/serial/by-id/usb-Arduino_Nano_33_BLE_3C48BB3E0BD44A03-if00
 
-.PHONY: clean hex flash
+.PHONY: clean all submodule-all monitor hex flash

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,19 @@ INCDIRS = -I$(ROOTDIR)/deps $(GENDIR)
 GCC	= $(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)gcc
 OBJDUMP	= $(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)objdump
 OBJCOPY = $(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)objcopy
+GREP    = grep
 
+
+
+# Newer GCC/binutils 2.36+ may require use of -march=rv32i_zicsr of inline __asm__ is used with CSRs
+GCC_COMPILER_SUPPORTS_ZICSR = $(shell $(GCC) -dumpspecs 2>/dev/null | $(GREP) -i -E "^march" | $(GREP) -i -c -E "_zicsr")
+ifeq ($(GCC_COMPILER_SUPPORTS_ZICSR),0)
+ CFLAGS_MARCH = -march=rv32i
+else
+ CFLAGS_MARCH = -march=rv32i_zicsr
+endif
 # VexRiscV on Caravel
-CFLAGS_ARCH	=	-mabi=ilp32 -march=rv32i -D__vexriscv__ -mstrict-align
+CFLAGS_ARCH	=	-mabi=ilp32 $(CFLAGS_MARCH) -D__vexriscv__ -mstrict-align
 
 #
 #CFLAGS_CODEGEN	= -O0

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ OBJCOPY = $(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)objcopy
 CFLAGS_ARCH	=	-mabi=ilp32 -march=rv32i -D__vexriscv__ -mstrict-align
 
 #
-CFLAGS_CODEGEN	= -O0
+#CFLAGS_CODEGEN	= -O0
 # For caravel production reduce code size and amount of stack usage around function calls and
 #   set RiscV ABI minimum frame size (16 bytes) due to the limited RAM caravel has 1.5KiB.
-#CFLAGS_CODEGEN	=	-Os -fomit-frame-pointer -mpreferred-stack-boundary=4
+CFLAGS_CODEGEN	=	-Os -fomit-frame-pointer -mpreferred-stack-boundary=4
 
 CFLAGS		=	-Wall
 

--- a/deps/crt0_vex.S
+++ b/deps/crt0_vex.S
@@ -1,3 +1,8 @@
+.if .gasversion. >= 23800
+// Newer gas needs this option as it bumps the default RiscV ISA spec
+.option arch, +zicsr
+.endif
+
 .global main
 .global isr
 .global _start

--- a/tt02-test/Makefile
+++ b/tt02-test/Makefile
@@ -1,2 +1,6 @@
 PATTERN = demo
 include ../Makefile
+
+submodule-all: $(PATTERN).elf $(PATTERN).bin $(PATTERN).hex flash_tigard
+
+.PHONY: submodule-all


### PR DESCRIPTION
The biggest risk is the option change at CFLAGS_CODEGEN, use `size demo.elf` and examine asm with `objdump -D demo.elf` to see the improved codegen.  Objvouly needs testing and comparing with real silicon.
Caravel VexRiscV performance is greatly affected by the raw instruction count to achieve the same goal so the options seem to minimize that metric and also stack usage per method concerning nested recursion.

This should also work for anyone now if they checkout and fixup TOOLCHAIN_PATH and TOOLCHAIN_PREFIX which can also be overridden in environment so a CI system can build using a different toolchain more easily.